### PR TITLE
Fix test setup for 2FA coverage: add test deps, enable Lombok for tests, update tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,23 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.12.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>3.12.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
@@ -174,6 +191,13 @@
             				<version>${lombok.version}</version>
         				</path>
     				</annotationProcessorPaths>
+                    <testAnnotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </testAnnotationProcessorPaths>
     			</configuration>
 			</plugin>
         </plugins>

--- a/src/test/java/org/cswteams/ms3/rest/LoginRestEndpointTwoFactorTest.java
+++ b/src/test/java/org/cswteams/ms3/rest/LoginRestEndpointTwoFactorTest.java
@@ -17,8 +17,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.Authentication;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Set;
@@ -66,9 +66,16 @@ class LoginRestEndpointTwoFactorTest {
         when(blacklistService.isInBlackList(any())).thenReturn(false);
         when(authenticationManager.authenticate(any())).thenReturn(Mockito.mock(Authentication.class));
 
-        SystemUser user = new SystemUser();
-        user.setEmail("user@example.com");
-        user.setSystemActors(Set.of(SystemActor.PLANNER));
+        SystemUser user = new SystemUser(
+                "John",
+                "Doe",
+                "TAXCODE",
+                java.time.LocalDate.of(1990, 1, 1),
+                "user@example.com",
+                "password",
+                Set.of(SystemActor.PLANNER),
+                "tenant"
+        );
         user.setTwoFactorEnabled(true);
 
         CustomUserDetails details = new CustomUserDetails(1L, "John", "Doe", user.getEmail(), "encoded", user.getSystemActors(), "tenant");

--- a/src/test/java/org/cswteams/ms3/rest/TwoFactorRestEndpointTest.java
+++ b/src/test/java/org/cswteams/ms3/rest/TwoFactorRestEndpointTest.java
@@ -50,9 +50,16 @@ class TwoFactorRestEndpointTest {
     private Clock clock;
 
     private SystemUser buildUser() {
-        SystemUser user = new SystemUser();
-        user.setEmail("user@example.com");
-        user.setTenant("public");
+        SystemUser user = new SystemUser(
+                "John",
+                "Doe",
+                "TAXCODE",
+                java.time.LocalDate.of(1990, 1, 1),
+                "user@example.com",
+                "password",
+                Collections.emptySet(),
+                "public"
+        );
         user.setTwoFactorEnabled(false);
         return user;
     }

--- a/src/test/java/org/cswteams/ms3/security/TwoFactorAuthenticationServiceTest.java
+++ b/src/test/java/org/cswteams/ms3/security/TwoFactorAuthenticationServiceTest.java
@@ -153,9 +153,16 @@ class TwoFactorAuthenticationServiceTest {
     }
 
     private SystemUser buildUser(Set<SystemActor> roles, boolean twoFactorEnabled) {
-        SystemUser user = new SystemUser();
-        user.setEmail("user@example.com");
-        user.setSystemActors(roles);
+        SystemUser user = new SystemUser(
+                "John",
+                "Doe",
+                "TAXCODE",
+                java.time.LocalDate.of(1990, 1, 1),
+                "user@example.com",
+                "password",
+                roles,
+                "public"
+        );
         user.setTwoFactorEnabled(twoFactorEnabled);
         user.setTwoFaVersionOrSalt("v1");
         return user;


### PR DESCRIPTION
### Motivation
- CI/local `mvn test` was failing with compilation errors in 2FA-related tests due to missing test dependencies and Lombok not being applied to test sources. 
- Several tests attempted to instantiate `SystemUser` via a no-arg constructor that is `protected`, causing compile-time errors. 
- Some tests imported the wrong `Authentication` type and relied on Mockito JUnit 5 support that wasn't present. 
- Make the test setup consistent so backend 2FA unit/webmvc tests can run in the documented `container,test` profile.

### Description
- Added test dependencies `spring-security-test`, `mockito-core`, and `mockito-junit-jupiter` to `pom.xml` and enabled Lombok annotation processing for test sources via `testAnnotationProcessorPaths` in the `maven-compiler-plugin` configuration. 
- Updated `LoginRestEndpointTwoFactorTest`, `TwoFactorRestEndpointTest`, and `TwoFactorAuthenticationServiceTest` to import `org.springframework.security.core.Authentication` and to construct `SystemUser` instances using the public parameterized constructor instead of calling the protected no-arg constructor. 
- Minor test adjustments to align with Mockito 3 usage. 
- Changes committed with message: `Fix test setup for 2FA coverage`.

### Testing
- Attempted to run the full backend test suite with `SPRING_PROFILES_ACTIVE=container,test mvn -DskipFrontendTests=true test`, but Maven failed early with a non-resolvable parent POM error (HTTP 403 when contacting `repo.maven.apache.org`), so the test run could not complete. 
- Prior to the network/parent-POM issue the earlier failures were addressed (missing imports and constructor usage), but final compilation/tests could not be verified because Maven could not download required POM/artifacts. 
- No frontend/Jest tests were executed as part of this run due to the Maven failure; further CI/test runs should be retried after resolving the repository/network access to Maven Central.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946bc6cb9d48329ab6d0f23897c2b43)