### PR TITLE
Fix test setup for 2FA: add test deps, update tests, remove invalid compiler config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,23 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.12.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>3.12.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>

--- a/src/test/java/org/cswteams/ms3/control/controllerscheduler/utils/TestDatesEnum.java
+++ b/src/test/java/org/cswteams/ms3/control/controllerscheduler/utils/TestDatesEnum.java
@@ -1,13 +1,10 @@
 package org.cswteams.ms3.control.controllerscheduler.utils;
 
-import lombok.Getter;
-
 import java.time.LocalDate;
 
 /**
  * Utility enumeration containing some useful dates often used in some tests.
  */
-@Getter
 public enum TestDatesEnum {
 
     /**
@@ -43,4 +40,8 @@ public enum TestDatesEnum {
      * Internal state.
      */
     private final LocalDate date;
+
+    public LocalDate getDate() {
+        return date;
+    }
 }

--- a/src/test/java/org/cswteams/ms3/rest/LoginRestEndpointTwoFactorTest.java
+++ b/src/test/java/org/cswteams/ms3/rest/LoginRestEndpointTwoFactorTest.java
@@ -17,8 +17,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.Authentication;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Set;
@@ -66,9 +66,16 @@ class LoginRestEndpointTwoFactorTest {
         when(blacklistService.isInBlackList(any())).thenReturn(false);
         when(authenticationManager.authenticate(any())).thenReturn(Mockito.mock(Authentication.class));
 
-        SystemUser user = new SystemUser();
-        user.setEmail("user@example.com");
-        user.setSystemActors(Set.of(SystemActor.PLANNER));
+        SystemUser user = new SystemUser(
+                "John",
+                "Doe",
+                "TAXCODE",
+                java.time.LocalDate.of(1990, 1, 1),
+                "user@example.com",
+                "password",
+                Set.of(SystemActor.PLANNER),
+                "tenant"
+        );
         user.setTwoFactorEnabled(true);
 
         CustomUserDetails details = new CustomUserDetails(1L, "John", "Doe", user.getEmail(), "encoded", user.getSystemActors(), "tenant");

--- a/src/test/java/org/cswteams/ms3/rest/TwoFactorRestEndpointTest.java
+++ b/src/test/java/org/cswteams/ms3/rest/TwoFactorRestEndpointTest.java
@@ -50,9 +50,16 @@ class TwoFactorRestEndpointTest {
     private Clock clock;
 
     private SystemUser buildUser() {
-        SystemUser user = new SystemUser();
-        user.setEmail("user@example.com");
-        user.setTenant("public");
+        SystemUser user = new SystemUser(
+                "John",
+                "Doe",
+                "TAXCODE",
+                java.time.LocalDate.of(1990, 1, 1),
+                "user@example.com",
+                "password",
+                Collections.emptySet(),
+                "public"
+        );
         user.setTwoFactorEnabled(false);
         return user;
     }

--- a/src/test/java/org/cswteams/ms3/security/TwoFactorAuthenticationServiceTest.java
+++ b/src/test/java/org/cswteams/ms3/security/TwoFactorAuthenticationServiceTest.java
@@ -153,9 +153,16 @@ class TwoFactorAuthenticationServiceTest {
     }
 
     private SystemUser buildUser(Set<SystemActor> roles, boolean twoFactorEnabled) {
-        SystemUser user = new SystemUser();
-        user.setEmail("user@example.com");
-        user.setSystemActors(roles);
+        SystemUser user = new SystemUser(
+                "John",
+                "Doe",
+                "TAXCODE",
+                java.time.LocalDate.of(1990, 1, 1),
+                "user@example.com",
+                "password",
+                roles,
+                "public"
+        );
         user.setTwoFactorEnabled(twoFactorEnabled);
         user.setTwoFaVersionOrSalt("v1");
         return user;


### PR DESCRIPTION
### Motivation
- Enable backend 2FA unit and WebMVC tests to compile and run by providing missing test libraries and fixing test code that assumed unavailable helpers. 
- Remove an unsupported `maven-compiler-plugin` configuration that attempted to enable Lombok annotation processing for test sources. 
- Fix test failures caused by usage of a protected no-arg `SystemUser` constructor and an incorrect `Authentication` import. 
- Make `TestDatesEnum` usable in tests without relying on test-time Lombok processing.

### Description
- Added test dependencies to `pom.xml`: `spring-security-test`, `mockito-core`, and `mockito-junit-jupiter`, and removed the unsupported `testAnnotationProcessorPaths` element from the compiler configuration. 
- Replaced uses of the protected `new SystemUser()` in tests with calls to the public parameterized `SystemUser` constructor in `LoginRestEndpointTwoFactorTest`, `TwoFactorRestEndpointTest`, and `TwoFactorAuthenticationServiceTest`. 
- Corrected the Spring Security import to `org.springframework.security.core.Authentication` in `LoginRestEndpointTwoFactorTest`. 
- Removed Lombok use from the test date helper and added an explicit `getDate()` method in `src/test/java/org/cswteams/ms3/control/controllerscheduler/utils/TestDatesEnum.java` so tests do not require test annotation processing.

### Testing
- After the changes, an attempted build/test run was executed with `SPRING_PROFILES_ACTIVE=container,test mvn -DskipFrontendTests=true test`. 
- The Maven invocation failed early due to an external dependency resolution issue: Maven could not download the parent Spring Boot starter POM from Maven Central (HTTP 403), so no unit or integration tests were executed. 
- Prior to the external repository failure, the previous compilation errors (missing imports and use of the protected constructor) were addressed by the code changes; however final verification is blocked by the repository access issue. 
- Recommendation: re-run `SPRING_PROFILES_ACTIVE=container,test mvn -DskipFrontendTests=true test` after restoring access to Maven Central or configuring an internal mirror so the parent POM and test dependencies can be resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946bc6cb9d48329ab6d0f23897c2b43)