### PR TITLE
Remove testAnnotationProcessorPaths from Maven Compiler Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,13 +191,6 @@
             				<version>${lombok.version}</version>
         				</path>
     				</annotationProcessorPaths>
-                    <testAnnotationProcessorPaths>
-                        <path>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                            <version>${lombok.version}</version>
-                        </path>
-                    </testAnnotationProcessorPaths>
     			</configuration>
 			</plugin>
         </plugins>


### PR DESCRIPTION
### Motivation
- Simplify the `maven-compiler-plugin` configuration by removing the redundant test annotation processor path block. 
- Rely on the existing Lombok `provided` dependency for test compilation so tests pick up Lombok via the normal dependency mechanism. 
- Keep build configuration minimal and avoid duplicate processor declarations unless a dedicated test path is required. 

### Description
- Removed the `<testAnnotationProcessorPaths>...</testAnnotationProcessorPaths>` section from the `maven-compiler-plugin` `<configuration>` in `pom.xml`.
- Left the primary `<annotationProcessorPaths>` (Lombok) intact so annotation processing for main sources is unchanged.
- Change scope is limited to the `pom.xml` file only.
- If a separate test processor path is later required, add an `<execution>` with `id` `test-compile`, `phase` `test-compile`, `goals` containing `testCompile`, and an execution-specific `<configuration>` with supported `<annotationProcessorPaths>`.

### Testing
- No automated tests were run as part of this change.
- Change is a build configuration update and should be validated by running `mvn -DskipTests=false test` in CI to confirm tests compile with Lombok on the classpath.
- Ensure CI uses the same dependency scopes so test compilation picks up Lombok provided dependency.
- No regressions in production code logic were introduced because only `pom.xml` was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947d01f3e588329a1093170b99c4b11)